### PR TITLE
Fix uuid deserialization

### DIFF
--- a/src/main/java/eu/pb4/factorytools/api/util/LegacyNbtHelper.java
+++ b/src/main/java/eu/pb4/factorytools/api/util/LegacyNbtHelper.java
@@ -1,6 +1,7 @@
 package eu.pb4.factorytools.api.util;
 
 import com.mojang.authlib.GameProfile;
+import com.mojang.serialization.Codec;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtIntArray;
@@ -19,9 +20,13 @@ public final class LegacyNbtHelper {
     private LegacyNbtHelper() {
     }
 
+    // Before 1.21.4 this class serialized using int array
+    // In 1.21.5 this was changed to Uuids.CODEC (string without dashes)
+    public static final Codec<UUID> UUID_CODEC = Codec.withAlternative(Uuids.INT_STREAM_CODEC, Uuids.CODEC);
+
     @Nullable
     public static GameProfile toGameProfile(NbtCompound nbt) {
-        UUID uUID = nbt.contains("Id") ? nbt.get("Id", Uuids.STRICT_CODEC).orElse(Util.NIL_UUID) : Util.NIL_UUID;
+        UUID uUID = nbt.contains("Id") ? nbt.get("Id", UUID_CODEC).orElse(Util.NIL_UUID) : Util.NIL_UUID;
         String string = nbt.getString("Name", "");
 
         try {


### PR DESCRIPTION
The GameProfile serialization code used to write the uuid as an int array. 
In the 1.21.5 port this was changed to `Uuids.CODEC` (uuid as string **without dashes**). The deserialization code was changed to read `Uuids.STRICT_CODEC`, which will try int array and if that doesn't succeed string, but **with dashes**.

So anytime anything uses this method to serialize and then deserialize again (eg through chunk unload and load) the Id field will get lost!