### PR TITLE
fix: update predicates to use ItemInstance instead of ItemStack

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ fabric_api_version=0.144.0+26.1
 polymer_version=0.16.0-pre.1+26.1-rc-2
 
 # Mod Properties
-	mod_version = 0.10.0-pre.1+26.1
+	mod_version = 0.10.0-pre.2+26.1
 	maven_group = eu.pb4
 	archives_base_name = factorytools
 

--- a/src/main/java/eu/pb4/factorytools/api/util/ExtraItemPredicates.java
+++ b/src/main/java/eu/pb4/factorytools/api/util/ExtraItemPredicates.java
@@ -3,10 +3,10 @@ package eu.pb4.factorytools.api.util;
 import java.util.HashMap;
 import java.util.function.Predicate;
 import net.minecraft.resources.Identifier;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemInstance;
 
 public class ExtraItemPredicates {
-    public static HashMap<Identifier, Predicate<ItemStack>> PREDICATES = new HashMap<>();
+    public static HashMap<Identifier, Predicate<ItemInstance>> PREDICATES = new HashMap<>();
 
     public static void register() {
 

--- a/src/main/java/eu/pb4/factorytools/mixin/ItemPredicateMixin.java
+++ b/src/main/java/eu/pb4/factorytools/mixin/ItemPredicateMixin.java
@@ -6,7 +6,7 @@ import eu.pb4.factorytools.impl.ExtendedItemPredicateCodec;
 import eu.pb4.factorytools.impl.ExtraItemPredicate;
 import net.minecraft.advancements.criterion.ItemPredicate;
 import net.minecraft.resources.Identifier;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemInstance;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -27,8 +27,8 @@ public class ItemPredicateMixin implements ExtraItemPredicate {
         CODEC = new ExtendedItemPredicateCodec(CODEC);
     }
 
-    @Inject(method = "test", at = @At("HEAD"), cancellable = true)
-    private void matchCustom(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+    @Inject(method = "test(Lnet/minecraft/world/item/ItemInstance;)Z", at = @At("HEAD"), cancellable = true)
+    private void matchCustom(ItemInstance stack, CallbackInfoReturnable<Boolean> cir) {
         if (customPredicate != null) {
             var predicate = ExtraItemPredicates.PREDICATES.get(customPredicate);
             if (predicate == null || !predicate.test(stack)) {


### PR DESCRIPTION
## Summary

in 26.1 `ItemPredicate#test` is now requires `ItemInstance`, not `ItemStack`. 
so on latest version, it occurs mixin error.

```
Caused by: org.spongepowered.asm.mixin.throwables.MixinApplyError: 
Mixin [factorytools.mixins.json:ItemPredicateMixin from mod factorytools] from phase [DEFAULT] in config 
[factorytools.mixins.json] FAILED during APPLY

Caused by: org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException: 
Invalid descriptor on factorytools.mixins.json:ItemPredicateMixin from mod factorytools->
@Inject::matchCustom(Lnet/minecraft/world/item/ItemStack;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfoReturnable;)V! 
Expected (Lnet/minecraft/world/item/ItemInstance;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfoReturnable;)V but found (Lnet/minecraft/world/item/ItemStack;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfoReturnable;)V
 [INJECT_APPLY Applicator Phase -> factorytools.mixins.json:ItemPredicateMixin from mod factorytools -> 
Apply Injections ->  -> Inject -> 
factorytools.mixins.json:ItemPredicateMixin from mod factorytools->
@Inject::matchCustom(Lnet/minecraft/world/item/ItemStack;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfoReturnable;)V]

```

this pr for resolve this issue.